### PR TITLE
Match on Req.Request to allow additional options (e.g. ipv6)

### DIFF
--- a/lib/ollama/api.ex
+++ b/lib/ollama/api.ex
@@ -66,6 +66,9 @@ defmodule Ollama.API do
   def new(%URI{} = url),
     do: struct(__MODULE__, req: Req.new(base_url: url))
 
+  def new(%Req.Request{} = req),
+    do: struct(__MODULE__, req: req)
+
   @doc false
   @spec mock(module() | fun()) :: t()
   def mock(plug) when is_atom(plug) or is_function(plug, 1),


### PR DESCRIPTION
Besides providing a binary or `%URI{}`, I'd like to be able to provide an ipv6 address. It currently fails because Req/Mint expects it as option (`inet6`). So instead I would suggest providing an additional match on `Req.Request{}`:

```Elixir
req = Req.new(base_url: "http://example-app.flycast/api", connect_options: [transport_opts: [inet6: true]])
api = Ollama.API.new(req)
Ollama.API.completion(api, [model: "llama2", prompt: "Why is the sky blue?"])
```