### PR TITLE
Add 'think' option to enable/disable step-by-step reasoning for models

### DIFF
--- a/lib/ollama.ex
+++ b/lib/ollama.ex
@@ -409,6 +409,11 @@ defmodule Ollama do
       default: false,
       doc: "See [section on streaming](#module-streaming).",
     ],
+    think: [
+      type: :boolean,
+      default: false,
+      doc: "Set `true` to have the model think step-by-step.",
+    ],
     keep_alive: [
       type: {:or, [:integer, :string]},
       doc: "How long to keep the model loaded.",
@@ -512,6 +517,11 @@ defmodule Ollama do
       type: {:or, [:boolean, :pid]},
       default: false,
       doc: "See [section on streaming](#module-streaming).",
+      ],
+    think: [
+      type: :boolean,
+      default: false,
+      doc: "Set `true` to have the model think step-by-step.",
     ],
     keep_alive: [
       type: {:or, [:integer, :string]},


### PR DESCRIPTION
Pretty small change, but allows for optional <think> toggling. Models that are compatible with thinking will also return you a blob of <think> ....... </think> text along with it's response. I didn't need this text in my case but wanted to use the model.