### PR TITLE
Add 'dimensions' parameter for embeddings

### DIFF
--- a/lib/ollama.ex
+++ b/lib/ollama.ex
@@ -956,7 +956,7 @@ defmodule Ollama do
       doc: "How long to keep the model loaded.",
     ],
     dimensions: [
-      type: {:or, [:integer, :string]},
+      type: :integer,
       doc: "The dimensions of the embedding vector to return (for models that support variable dimensions).",
     ],
     options: [

--- a/lib/ollama.ex
+++ b/lib/ollama.ex
@@ -955,6 +955,10 @@ defmodule Ollama do
       type: {:or, [:integer, :string]},
       doc: "How long to keep the model loaded.",
     ],
+    dimensions: [
+      type: {:or, [:integer, :string]},
+      doc: "The dimensions of the embedding vector to return (for models that support variable dimensions).",
+    ],
     options: [
       type: {:map, {:or, [:atom, :string]}, :any},
       doc: "Additional advanced [model parameters](https://github.com/jmorganca/ollama/blob/main/docs/modelfile.md#valid-parameters-and-values).",


### PR DESCRIPTION
Modified the schema to support the dimensions parameter of the Ollama embedding API:
https://github.com/ollama/ollama/blob/main/docs/api.md#generate-embeddings

Tested in LiveBook using `nomic-embed-text` setting the dimensions to 32 instead of the default 768:
https://gist.github.com/m-dreiling/62170bd2b1084c7add79591ce45780ac